### PR TITLE
Fill out get_home_page_snippet

### DIFF
--- a/ckan/ckanext-odata_org_il/ckanext/odata_org_il/plugin.py
+++ b/ckan/ckanext-odata_org_il/ckanext/odata_org_il/plugin.py
@@ -2,7 +2,6 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan.lib.plugins import DefaultTranslation
 
-
 class Odata_Org_IlPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.ITranslation)
     plugins.implements(plugins.IConfigurer)
@@ -19,10 +18,14 @@ class Odata_Org_IlPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return 'ckan'
 
     def get_homepage_snippet(self, *args, **kwargs):
-        # TODO: show last updated datasets
-        return ""
+        psearch = toolkit.get_action("package_search")
+        psearch_ret = psearch(data_dict={"sort":"timestamp desc","rows":10})
+        results = psearch_ret['results']
+        result_str_list = [ "Name: %(name)s<br>Notes: %(notes)s<br>Created:%(metadata_created)s<br>Modified:%(metadata_modified)s<br>URL:%(url)s" % entry for entry in results ] 
+        return "<br>".join(result_str_list)
 
     # Tell CKAN what custom template helper functions this plugin provides,
     # see the ITemplateHelpers plugin interface.
     def get_helpers(self):
         return {'get_homepage_snippet': self.get_homepage_snippet}
+

--- a/ckan/ckanext-odata_org_il/ckanext/odata_org_il/templates/home/layout-odata.html
+++ b/ckan/ckanext-odata_org_il/ckanext/odata_org_il/templates/home/layout-odata.html
@@ -12,6 +12,6 @@
 </div>
 <div role="main">
   <div class="container">
-	{{ h.get_homepage_snippet() }}
+	{{ h.get_homepage_snippet()|safe }}
   </div>
 </div>


### PR DESCRIPTION
retrieve last ten created/modified packages using server side package_search
action. Added the safe filter to template to prevent escaping of HTML.

https://github.com/OriHoch/data4dappl/issues/36