### PR TITLE
Update odata-theme.css - Fix for firefox overscrolling

### DIFF
--- a/ckan/ckanext-odata_org_il/ckanext/odata_org_il/fanstatic/odata-theme.css
+++ b/ckan/ckanext-odata_org_il/ckanext/odata_org_il/fanstatic/odata-theme.css
@@ -1,3 +1,14 @@
+body {
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+}
+
+html {
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+}
 
 .masthead .nav>li>a, .masthead .nav>li>a:focus, .masthead .nav>li>a:hover, .masthead .nav>.active>a, .masthead .nav>.active>a:hover, .masthead .nav>.active>a:focus {
     font-weight: bold;


### PR DESCRIPTION
While I'm already here...

On firefox the website has scrolling problems - especially visible on mobile (see screen capture below).
These css fixes should fix them (while not affecting or Safari as far as I could tell)

https://github.com/user-attachments/assets/863043dc-81f8-44c8-bee9-852211c5549c

